### PR TITLE
Missing namespace references

### DIFF
--- a/broadcasting.md
+++ b/broadcasting.md
@@ -184,6 +184,8 @@ The server-side logic that handles the subscription is more interesting:
 
 ```cs
 using Unisave;
+using Unisave.Authentication;
+using Unisave.Broadcasting;
 using Unisave.Facades;
 using Unisave.Facets;
 


### PR DESCRIPTION
Missing Authentication and Broadcasting references in the JoinRoom method for AuthException() and using Broadcast functions